### PR TITLE
#feat create wallet account on signup

### DIFF
--- a/src/app/signup/signup.component.spec.ts
+++ b/src/app/signup/signup.component.spec.ts
@@ -61,12 +61,16 @@ describe('SignupComponent', () => {
     component.emailChange('ejykken@gmail');
     expect(component.errors.email).toEqual('The email format is invalid.');
   });
-  it('should call save method ', () => {
+  it('should call component methods method ', () => {
     const user = { id:1, token: 'sgshhs', guid: '242fsfsg'}
+    component.createAccount(user)
     component.save(user);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/account']);
     const save = spyOn(component, 'save')
+    const createAccount = spyOn(component, 'createAccount')
     component.save(user);
+    component.createAccount(user)
     expect(save).toHaveBeenCalled()
+    expect(createAccount).toHaveBeenCalled()
   });
 });

--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -23,6 +23,7 @@ export class SignupComponent implements OnInit {
     name: null,
     password: null,
   };
+  user: any = {}
   @Output() onSubmit = new EventEmitter<boolean>();
   
   actions = new EventEmitter<string|MaterializeAction>();
@@ -38,8 +39,8 @@ export class SignupComponent implements OnInit {
       this.errors.email = validator.errors.first('email')
     }
   }
+
   save(user) {
-    console.log(user)
     const { id, token, guid, email } = user;
     this.AuthService.authenticate(id, token, guid, email)
     const message = 'SignUp successful'
@@ -48,6 +49,16 @@ export class SignupComponent implements OnInit {
     this.actions.emit({action:"modal",params:['close']});
     this.router.navigate(['/account'])
   }
+
+  createAccount(user) {
+    this.user = user
+    const url = `${host}/v1/wallet/accounts`;
+      this.WalletService.post(url, user.name).subscribe(
+        account => this.save(this.user),
+        error => this.save(this.user)
+      )
+  }
+
   submit() {
     this.errors = {}
     const data = {
@@ -71,7 +82,7 @@ export class SignupComponent implements OnInit {
     if (!isError) {
       const url = `${host}/v1/auth/signup`;
       this.WalletService.post(url, data).subscribe(
-        user => this.save(user),
+        user => this.createAccount(user),
         error => Alert('SignUp', 'error', error.error.errors, 3000)
       )
     }


### PR DESCRIPTION

#### What does this PR do?
- create wallet account on signup

#### Description
- add a method that make an api call to create a wallet account
- add test

#### How should this be manually tested?
- Navigate to the homepage on the heroku to view the wallet page
- or git fetch the branch using `git fetch origin ft-create-wallet-account-on-signup`
- run `npm start`
- signup and wallet and its account will be created
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A

